### PR TITLE
Allowing the dynamic definition of methods to retrieve tabular data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ### Bug Fixes
 
+## 0.3.1 (unreleased)
+
+### New Features
+
+- Allowing to set the tabular_data_tables dynamically instead of just using the ones provided so that it allow developer to retrieve custom information. At this time it is currently in **beta**. ([@rrodriguez-gap][])
+ 
+### Changes
+- Overwritting the method_missing default functionality to dynamically generate the actions 
+
 ## 0.3.0 (2019-08-15)
 
 ### New Features
@@ -60,3 +69,4 @@
 [@nlively]: https://github.com/nlively
 [@danhealy]: https://github.com/danhealy
 [@cabello]: https://github.com/cabello
+[@rrodriguez-gap]: https://github.com/rrodriguez-gap

--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -18,8 +18,8 @@ require "bamboozled/api/meta"
 module Bamboozled
   class << self
     # Creates a standard client that will raise all errors it encounters
-    def client(subdomain: nil, api_key: nil, httparty_options: {})
-      Bamboozled::Base.new(subdomain: subdomain, api_key: api_key, httparty_options: httparty_options)
+    def client(subdomain: nil, api_key: nil, httparty_options: {}, tabular_data_tables: [])
+      Bamboozled::Base.new(subdomain: subdomain, api_key: api_key, httparty_options: httparty_options, tabular_data_tables: tabular_data_tables)
     end
   end
 end

--- a/lib/bamboozled/base.rb
+++ b/lib/bamboozled/base.rb
@@ -2,14 +2,15 @@ module Bamboozled
   class Base
     attr_reader :request
 
-    def initialize(subdomain: nil, api_key: nil, httparty_options: {})
+    def initialize(subdomain: nil, api_key: nil, httparty_options: {}, tabular_data_tables: [])
       @subdomain, @api_key = subdomain
       @api_key = api_key
       @httparty_options = httparty_options
+      @tabular_data_tables = tabular_data_tables
     end
 
     def employee
-      @employee ||= Bamboozled::API::Employee.new(@subdomain, @api_key, @httparty_options)
+      @employee ||= Bamboozled::API::Employee.new(@subdomain, @api_key, @httparty_options, @tabular_data_tables)
     end
 
     def report

--- a/lib/bamboozled/version.rb
+++ b/lib/bamboozled/version.rb
@@ -1,3 +1,3 @@
 module Bamboozled
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1".freeze
 end

--- a/spec/fixtures/add_employee_xml.yml
+++ b/spec/fixtures/add_employee_xml.yml
@@ -4,5 +4,4 @@ headers:
   Accept:
   - application/json
   User-Agent:
-  - Bamboozled/0.3.0
-
+  - Bamboozled/0.3.1

--- a/spec/fixtures/update_employee_xml.yml
+++ b/spec/fixtures/update_employee_xml.yml
@@ -4,5 +4,5 @@ headers:
   Accept:
   - application/json
   User-Agent:
-  - Bamboozled/0.3.0
+  - Bamboozled/0.3.1
 

--- a/spec/lib/bamboozled/base_spec.rb
+++ b/spec/lib/bamboozled/base_spec.rb
@@ -2,11 +2,19 @@ require "spec_helper"
 
 RSpec.describe "Bamboozled::Base" do
   let(:base) { Bamboozled::Base.new(subdomain: "x", api_key: "x", httparty_options: {log_format: :curl}) }
+  let(:employee_base) { Bamboozled::Base.new(subdomain: "x", api_key: "x", httparty_options: {},
+                                             tabular_data_tables: [:job_info]) }
 
   it "passes HTTParty options to Bamboozled::API::Employee constructor" do
-    expect(Bamboozled::API::Employee).to receive(:new).with("x", "x", { log_format: :curl })
+    expect(Bamboozled::API::Employee).to receive(:new).with("x", "x", { log_format: :curl }, [])
     base.employee
   end
+
+  it "passes tabular_data_tables options to Bamboozled::API::Employee constructor" do
+    expect(Bamboozled::API::Employee).to receive(:new).with("x", "x", {}, [:job_info])
+    employee_base.employee
+  end
+
   it "passes HTTParty options to Bamboozled::API::Report constructor" do
     expect(Bamboozled::API::Report).to receive(:new).with("x", "x", { log_format: :curl })
     base.report

--- a/spec/lib/bamboozled_spec.rb
+++ b/spec/lib/bamboozled_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Bamboozled" do
   it "takes HTTParty options as a parameter" do
-    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl })
+    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl }, tabular_data_tables:[] )
     Bamboozled.client(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl })
   end
 
@@ -23,6 +23,20 @@ RSpec.describe "Bamboozled" do
   end
 
   it "works without HTTParty options provided" do
+    client = Bamboozled.client(subdomain: "x", api_key: "x")
+    response = File.new("spec/fixtures/one_employee.json")
+    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+    employee = client.employee.find(1234)
+    expect(employee["firstName"]).to eq "John"
+  end
+
+  it "takes tabular_data_tables options as a parameter" do
+    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_key: "x", httparty_options: {}, tabular_data_tables: [:job_info])
+    Bamboozled.client(subdomain: "x", api_key: "x", httparty_options: {}, tabular_data_tables: [:job_info])
+  end
+
+  it "works without tabularDataMethods options provided" do
     client = Bamboozled.client(subdomain: "x", api_key: "x")
     response = File.new("spec/fixtures/one_employee.json")
     stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)


### PR DESCRIPTION
Performed changes:
 - Adding a new parameter to the definition of the initialize for bamboozled
 - tabular_data_tables: will have as default the original list provided in the gem, appending the 2 items
 - Overwritting the method_missing so that it's possible to handle dynamic definition for the methods based on the provided parameters.
 - Overwritting the respond_to_missing? method to include as well the methods that we provide as parameters for the client definition
 - Updating Version number
 - Updating the rspecs to match the new requirements
 - Updating CHANGELOG

## Description
Adding the possibility of getting information from custom tabular data. The performed changes include the possibility to pass as parameters any new tabular information that we may require to get information from.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
